### PR TITLE
Temporarily disable URL checking for version 1.3.2

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -177,10 +177,11 @@ function checkUrl(urlId) {
       const freshUrl = freshUrls.find(u => u.id === urlId);
       if (!freshUrl) return;
 
-      if (freshUrl.isChecking) {
-        console.log('Check already in progress for URL:', freshUrl.name);
-        return;
-      }
+      // temporary disable checking because stuck in checking
+      // if (freshUrl.isChecking) {
+      //   console.log('Check already in progress for URL:', freshUrl.name);
+      //   return;
+      // }
 
       // Mark as checking
       freshUrl.isChecking = true;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "RSS Feed Warrior",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Get notifications from your favorite websites at specified intervals, inspired by Collie Notifier App and FeedBro Extension.",
   "icons": {
   "16": "assets/icon16.png",


### PR DESCRIPTION
Disable the URL checking mechanism to resolve issues with it getting stuck, while updating the version number to 1.3.2.